### PR TITLE
add settings configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ event1.remove();
 myCon.stop();
 ```
 
+##Additional options
+In order to customize the connection options, you can provide your own settings passing a second argument object to the connection function.
+```
+var mysqlEventWatcher = MySQLEvents(dsn, {
+  startAtEnd: false // it overrides default value "true"
+});
+```
+You can find the list of the available options [here](https://github.com/nevill/zongji#zongji-class).
+
 #Watcher Setup
 Its basically a dot '.' seperated string. It can have the following combinations
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function zongjiManager(dsn, options, onBinlog) {
     return newInst;
 }
 
-var MySQLEvents = function(dsn) {
+var MySQLEvents = function(dsn, settings) {
   var mySQLEvents = {
     //Watching - to check whether the zongji.on() has been called or not
     started: false,
@@ -50,6 +50,9 @@ var MySQLEvents = function(dsn) {
     triggers: [],
     
     dsn,
+
+    //settings available - serverId, startAtEnd, binlogName, binlogNextPos, includeEvents, excludeEvents, includeSchema, excludeSchema
+    settings: settings || {},
 
     //connect - instantiate an ZongJi Class
     connect: function(dsn) {
@@ -105,6 +108,8 @@ var MySQLEvents = function(dsn) {
         includeEvents: this.events,
         includeSchema: this.includeSchema()
       };
+      //override default settings
+      Object.assign(map, this.settings);
 
       //check whether ZongJi started
       if (!this.started) {


### PR DESCRIPTION
This PR is intended to implement the possibility to override default options. I called the configuration object `settings` to avoid confusion with the `options` parameter defined in `zongjiManager(dsn, options, onBinlog)`. Available options are [described here](https://github.com/nevill/zongji/blob/master/README.md#zongji-class) and can be useful in many scenario.

A documentation update could be necessary to provide information about this configuration object.