### PR TITLE
Feature/return event information

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ var dsn = {
 var mysqlEventWatcher = MySQLEvents(dsn);
 var watcher =mysqlEventWatcher.add(
   'myDB.table.field.value',
-  function (oldRow, newRow) {
+  function (oldRow, newRow, event) {
      //row inserted
     if (oldRow === null) {
       //insert code goes here
@@ -29,6 +29,9 @@ var watcher =mysqlEventWatcher.add(
     if (oldRow !== null && newRow !== null) {
       //update code goes here
     }
+
+    //detailed event information
+    //console.log(event)
   }, 
   'match this string or regex'
 );
@@ -61,7 +64,7 @@ Make sure the database user has the privilege to read the binlog on database tha
 ```sh
 var event1 = myCon.add(
   'dbName.tableName.fieldName.value',
-  function (oldRow, newRow) {
+  function (oldRow, newRow, event) {
     //code goes here
   }, 
   'Active'

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ var MySQLEvents = function(dsn, settings) {
                 return t.trigger == database;
               });
               _underScore.each(dbTriggers, function(dbTrigger) {
-                dbTrigger.callback.call(dbTrigger, oldRow, newRow);
+                dbTrigger.callback.call(dbTrigger, oldRow, newRow, evt);
               });
 
               //call all database.table callbacks
@@ -188,7 +188,7 @@ var MySQLEvents = function(dsn, settings) {
                 return t.trigger == database + '.' + table;
               });
               _underScore.each(tblTriggers, function(tblTrigger) {
-                tblTrigger.callback.call(tblTrigger, oldRow, newRow);
+                tblTrigger.callback.call(tblTrigger, oldRow, newRow, evt);
               });
 
               //call all database.table.column, database.table.column, database.table.column.value & database.table.column.regexp callbacks
@@ -199,10 +199,10 @@ var MySQLEvents = function(dsn, settings) {
                 });
                 _underScore.each(colTriggers, function(colTrigger) {
                   if (_underScore.isUndefined(colTrigger.value)) {
-                    colTrigger.callback.call(colTrigger, oldRow, newRow);
+                    colTrigger.callback.call(colTrigger, oldRow, newRow, evt);
                   }
                   else if (row.after[col] == colTrigger.value) {
-                    colTrigger.callback.call(colTrigger, oldRow, newRow);
+                    colTrigger.callback.call(colTrigger, oldRow, newRow, evt);
                   }
                 });
                 //regexp match
@@ -211,7 +211,7 @@ var MySQLEvents = function(dsn, settings) {
                 });
                 _underScore.each(colTriggers, function(colTrigger) {
                   if (!_underScore.isUndefined(colTrigger.value) && colTrigger.value.test(row.after[col])) {
-                    colTrigger.callback.call(colTrigger, oldRow, newRow);
+                    colTrigger.callback.call(colTrigger, oldRow, newRow, evt);
                   }
                 });
               });


### PR DESCRIPTION
This feature is meant to provide to the user the possibility to evaluate the `event` object on the callback context. This can be useful when the user want to evaluate technical data as `event.timestamp`, `event.nextPosition` and `event._zongji.binlogName` and others.
The change won't affect actual implementations but it will be become essential for advanced use cases.